### PR TITLE
Add XDG Base Directory support and improve help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Then copy the configuration file to your WITCH installation folder. For example:
 and replace `<your-username>`, or change the whole path if you prefer.
 This is the path where all the files will be stored. A new subfolder will be created
 for each commit with files to store.
+In alternative, `config.ini` can be copied to `$XDG_CONFIG_HOME/gdxstore/` or `~/.config/gdxstore/`.
+The script first checks the current directory for the configuration file, then the two folders above, as
+a global default.
 The plan is to add more global options to `config.ini`, such as default gdxdiff tolerances
 and the log history start date.
 If on juno or cassandra, in order to let other people use your directory for storage, you need to

--- a/source/gdxstore.py
+++ b/source/gdxstore.py
@@ -301,6 +301,11 @@ def main():
 
     args = parser.parse_args()
 
+    # Show help if no arguments provided
+    if not (args.s or args.d or args.log):
+        parser.print_help()
+        return
+
     # Storage
     if args.s:
         for file in args.files:    

--- a/source/gdxstore.py
+++ b/source/gdxstore.py
@@ -282,7 +282,20 @@ def main():
     default_storage_folder = conf['storage'].get('storage_folder') if conf.has_section('storage') else None
 
     # Command line options
-    parser = argparse.ArgumentParser(description='Store and inspect GDX files')
+    epilog_text = f"""
+Configuration file locations (checked in order):
+  1. ./config.ini (current directory)
+  2. {os.path.join(xdg_config_home, 'gdxstore', 'config.ini')}
+
+The config.ini file should contain:
+  [storage]
+  storage_folder = /path/to/your/storage/folder
+"""
+    parser = argparse.ArgumentParser(
+        description='Store and inspect GDX files',
+        epilog=epilog_text,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument('-s', action='store_true',
                        help='Store a file')
     parser.add_argument('-d', action='store_true',

--- a/source/gdxstore.py
+++ b/source/gdxstore.py
@@ -276,8 +276,10 @@ class GDXStore:
 def main():
     # Default settings
     conf = RawConfigParser()
-    conf.read('config.ini')
-    default_storage_folder = conf['storage'].get('storage_folder')
+    xdg_config_home = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
+    config_files = ['config.ini', os.path.join(xdg_config_home, 'gdxstore', 'config.ini')]
+    conf.read(config_files)
+    default_storage_folder = conf['storage'].get('storage_folder') if conf.has_section('storage') else None
 
     # Command line options
     parser = argparse.ArgumentParser(description='Store and inspect GDX files')


### PR DESCRIPTION
This PR adds the following improvements:

- **XDG Base Directory support**: Config file is now searched in `$XDG_CONFIG_HOME/gdxstore/config.ini` (or `~/.config/gdxstore/config.ini`) in addition to the current directory's `config.ini`
- **Usage help text**: Shows help automatically when no arguments are provided
- **Config documentation**: Help text now includes information about where to place the config.ini file and what it should contain

Config file locations are checked in this order:
1. `./config.ini` (current directory - takes precedence for backward compatibility)
2. `$XDG_CONFIG_HOME/gdxstore/config.ini` (or `~/.config/gdxstore/config.ini`)

This follows XDG Base Directory specification best practices while maintaining backward compatibility.